### PR TITLE
feat: connection preheating

### DIFF
--- a/src/pkg/conf/spec.rs
+++ b/src/pkg/conf/spec.rs
@@ -13,16 +13,6 @@ pub struct HttpRoute {
     pub rewrite: Option<String>,
 }
 
-impl HttpRoute {
-    pub async fn connect(&self) -> TcpStream {
-        let destination = format!("{}:{}", &self.target_host, &self.target_port);
-        tracing::debug!("connecting to remote: {}", &destination);
-        let conn = TcpStream::connect(&destination).await.unwrap();
-        tracing::info!("✅ Connected to upstream: {:?}", &self);
-        conn
-    }
-}
-
 #[derive(Deserialize, Debug, Clone)]
 pub struct Http {
     #[serde(default = "default_http_kind")]
@@ -36,16 +26,6 @@ pub struct Http {
 pub struct TcpRoute {
     pub target_host: String,
     pub target_port: i32,
-}
-
-impl TcpRoute {
-    pub async fn connect(&self) -> TcpStream {
-        let destination = format!("{}:{}", &self.target_host, &self.target_port);
-        tracing::debug!("connecting to remote: {}", &destination);
-        let conn = TcpStream::connect(&destination).await.unwrap();
-        tracing::info!("✅ Connected to upstream: {:?}", &self);
-        conn
-    }
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/src/pkg/conf/spec.rs
+++ b/src/pkg/conf/spec.rs
@@ -3,8 +3,6 @@ use std::i32;
 use serde::de::Error;
 use serde::{Deserialize, Deserializer};
 use serde_yaml::Value;
-use tokio::net::TcpStream;
-
 #[derive(Deserialize, Debug, Clone)]
 pub struct HttpRoute {
     pub host: Option<String>,

--- a/src/pkg/server/http.rs
+++ b/src/pkg/server/http.rs
@@ -69,7 +69,6 @@ impl ForwardRoutes for Router<Vec<HttpRoute>> {
         server_tx: Sender<Vec<u8>>,
     ) -> Result<()> {
         while let Ok(mut msg) = client_rx.recv().await {
-            //TODO: add streaming/websocket support later
             let path = extract_path(&msg);
             tracing::info!("received http message at {}", &path);
             match self.at(&path) {
@@ -80,6 +79,7 @@ impl ForwardRoutes for Router<Vec<HttpRoute>> {
                     tracing::info!("got matching route, routing to {:?}", &route);
                     let (tx, mut rx) = broadcast::channel::<Vec<u8>>(1);
                     route.connect(tx.clone()).await;
+                    // TODO: this is blocking, fix it
                     if let Some(rewrite) = route.rewrite {
                         let rewrite_key = path.replace(matched.params.get("p").unwrap_or(""), "");
                         tracing::info!("rewriting path: {} to {}", &rewrite_key, &rewrite);

--- a/src/pkg/server/http.rs
+++ b/src/pkg/server/http.rs
@@ -71,10 +71,8 @@ impl ForwardRoutes for Router<Vec<HttpRoute>> {
         let (proxy_tx, proxy_rx) = broadcast::channel::<Vec<u8>>(1);
         let (upstream_tx, mut upstream_rx) = broadcast::channel::<Vec<u8>>(1);
         tokio::select! {
-            //_ = route.listen(proxy_rx, upstream_tx) => {},
             _ = async{
                 while let Ok(mut msg) = client_rx.recv().await {
-
                     let path = extract_path(&msg);
                     tracing::info!("received http message at {}", &path);
                     match self.at(&path) {
@@ -91,10 +89,6 @@ impl ForwardRoutes for Router<Vec<HttpRoute>> {
                                     format!("/{}", &rewrite_key).into(),
                                     rewrite.into(),
                                 )
-                            }
-                            if let Err(e) = proxy_tx.send(msg){
-                                eprintln!("error sending msg: {}", e);
-                                break;
                             }
                         }
                         Err(_) => {

--- a/src/pkg/server/http.rs
+++ b/src/pkg/server/http.rs
@@ -17,6 +17,19 @@ impl HttpRoute {
     }
 }
 
+impl HttpRoute {
+    pub async fn listen_upstream(&self) -> (Sender<Vec<u8>>, Receiver<Vec<u8>>){
+        let (proxy_tx, proxy_rx) = broadcast::channel::<Vec<u8>>(1);
+        let (upstream_tx, upstream_rx) = broadcast::channel::<Vec<u8>>(1);
+        TcpRoute{
+            target_host: self.target_host.clone(),
+            target_port: self.target_port
+        }.listen(proxy_rx, upstream_tx).await;
+        (proxy_tx, upstream_rx)
+    }
+}
+
+
 
 #[async_trait]
 impl SpawnServers for HttpRoutes {

--- a/src/pkg/server/http.rs
+++ b/src/pkg/server/http.rs
@@ -1,15 +1,22 @@
-use crate::{pkg::conf::spec::HttpRoute, prelude::Result};
+use crate::{pkg::conf::spec::{HttpRoute, TcpRoute}, prelude::Result};
 use async_trait::async_trait;
 use matchit::Router;
 use rand::Rng;
-use regex::bytes::Regex;
 use tokio::{
-    io::{AsyncReadExt, AsyncWriteExt},
-    sync::broadcast::{Receiver, Sender},
-    task::JoinSet,
+    io::{AsyncReadExt, AsyncWriteExt}, net::TcpStream, sync::broadcast::{Receiver, Sender}, task::JoinSet
 };
 
 use super::{proxy::spawn_tcp_server, ForwardRoutes, HttpRoutes, SpawnServers};
+
+impl HttpRoute {
+    pub async fn connect(&self) -> TcpStream {
+        TcpRoute{
+            target_host: self.target_host.clone(),
+            target_port: self.target_port
+        }.connect().await
+    }
+}
+
 
 #[async_trait]
 impl SpawnServers for HttpRoutes {

--- a/src/pkg/server/mod.rs
+++ b/src/pkg/server/mod.rs
@@ -16,10 +16,12 @@ mod tcp;
 pub type TcpRoutes = HashMap<i32, Vec<TcpRoute>>;
 pub type HttpRoutes = HashMap<i32, Router<Vec<HttpRoute>>>;
 
+
 #[derive(Debug)]
 pub struct Server {
     tcp_routes: TcpRoutes,
     http_routes: HttpRoutes,
+    upstream_chans: HashMap<i32, (Sender<Vec<u8>>, Receiver<Vec<u8>>)>
 }
 
 impl Server {
@@ -30,6 +32,10 @@ impl Server {
             _ = self.http_routes.spawn() => {},
             _ = tokio::signal::ctrl_c() => {}
         }
+    }
+
+    pub async fn preheat_upstream(&mut self){
+
     }
 }
 

--- a/src/pkg/server/mod.rs
+++ b/src/pkg/server/mod.rs
@@ -26,8 +26,8 @@ impl Server {
     pub async fn start(&self) {
         tracing::info!("starting proxy");
         tokio::select! {
-            _ = self.tcp_routes.listen() => {},
-            _ = self.http_routes.listen() => {},
+            _ = self.tcp_routes.spawn() => {},
+            _ = self.http_routes.spawn() => {},
             _ = tokio::signal::ctrl_c() => {}
         }
     }
@@ -41,7 +41,7 @@ pub trait ForwardRoutes {
 
 #[async_trait]
 pub trait SpawnServers {
-    async fn listen(&self) -> Result<()>;
+    async fn spawn(&self) -> Result<()>;
 }
 
 #[cfg(test)]

--- a/src/pkg/server/proxy.rs
+++ b/src/pkg/server/proxy.rs
@@ -54,7 +54,6 @@ where
                     break;
                 }
                 let body = buf[..n].to_vec();
-                tracing::debug!("passing client message: {:?}", String::from_utf8(body.clone()));
                 client_tx.send(body)?;
             }
             Ok::<(), ProxyError>(())

--- a/src/pkg/server/tcp.rs
+++ b/src/pkg/server/tcp.rs
@@ -1,4 +1,5 @@
 use rand::Rng;
+use tokio::net::TcpStream;
 use tokio::task::JoinSet;
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
@@ -12,6 +13,17 @@ use crate::{
 use async_trait::async_trait;
 
 use super::{proxy::spawn_tcp_server, ForwardRoutes, SpawnServers};
+
+
+impl TcpRoute {
+    pub async fn connect(&self) -> TcpStream {
+        let destination = format!("{}:{}", &self.target_host, &self.target_port);
+        tracing::debug!("connecting to remote: {}", &destination);
+        let conn = TcpStream::connect(&destination).await.unwrap();
+        tracing::info!("✅ Connected to upstream: {:?}", &self);
+        conn
+    }
+}
 
 #[async_trait]
 impl SpawnServers for TcpRoutes {

--- a/src/pkg/server/tcp.rs
+++ b/src/pkg/server/tcp.rs
@@ -1,5 +1,6 @@
 use rand::Rng;
 use tokio::net::TcpStream;
+use tokio::sync::broadcast;
 use tokio::task::JoinSet;
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
@@ -16,12 +17,13 @@ use super::{proxy::spawn_tcp_server, ForwardRoutes, SpawnServers};
 
 
 impl TcpRoute {
-    pub async fn connect(&self) -> TcpStream {
+    pub async fn connect(&self) -> (Sender<Vec<u8>>, Receiver<Vec<u8>>) {
         let destination = format!("{}:{}", &self.target_host, &self.target_port);
         tracing::debug!("connecting to remote: {}", &destination);
         let conn = TcpStream::connect(&destination).await.unwrap();
+        let (tx, rx) = broadcast::channel::<Vec<u8>>(1);
         tracing::info!("✅ Connected to upstream: {:?}", &self);
-        conn
+        (tx, rx)
     }
 }
 

--- a/src/pkg/server/tcp.rs
+++ b/src/pkg/server/tcp.rs
@@ -25,6 +25,7 @@ impl TcpRoute {
         let mut buffer = vec![0; 1024];
         let mut rx = tx.subscribe();
         let (mut recv, mut send) = stream.split();
+        //TODO: messages are being mirrored back, fix it
         tokio::select! {
             _ = async{
                 loop {


### PR DESCRIPTION
- preheating tcp connections 
- returning byte channel instead of tcp stream
- updated forward and listen to concurrently read and write to client and upstream

## TODO: bug fixes
- tcp packets are mirrored
- http forward is blocking at channel read